### PR TITLE
Updated textFamily property in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ function Button() {
 | textColor             | `String`      | `#FFFFFF` | Button default label text color                           |
 | textLineHeight        | `Number`      | `20`      | Button default label text line height                     |
 | textSize              | `Number`      | `16`      | Button default label text font size                       |
-| textFamily            | `Number`      | `null`    | Button default label text font family                     |
+| textFontFamily        | `String`      | `null`    | Button default label text font family                     |
 | style                 | `Style`       | `null`    | Button container custom styles                            |
 
 ## Web version


### PR DESCRIPTION
Fixes #21 

Changed the property textFamily to textFontFamily and it's type from Number to String.

[Rendered markdown](https://github.com/rcaferati/react-native-really-awesome-button/blob/f4025357a89105ab9d1765a283c09d6ff04d3b78/README.md#props)
