### PR TITLE
TypeScript fix for AwesomeButtonProps.onPress

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,8 @@ declare module "react-native-really-awesome-button" {
   import React, { Component } from "react";
   import { ViewStyle } from "react-native";
 
+  type AfterPressFn = (callback: () => void) => void;
+
   export interface AwesomeButtonProps {
     activityColor?: string;
     backgroundActive?: string;
@@ -39,7 +41,7 @@ declare module "react-native-really-awesome-button" {
     textSize?: number;
     textFamily?: string;
     width?: number;
-    onPress?(): void;
+    onPress?: (afterPressFn?: AfterPressFn) => void;
   }
 
   export default class AwesomeButton extends Component<


### PR DESCRIPTION
This patch makes one minor correction to `index.d.ts`:

- `onPress()` takes an optional "after press" parameter that is a function that accepts a callback. Update the TypeScript types to reflect this.

Happy user of your button component here! Appreciate the work you've put into this, and glad to see you're adding TypeScript support.