### PR TITLE
Fix textFontFamily

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,7 @@ declare module "react-native-really-awesome-button" {
     textColor?: string;
     textLineHeight?: number;
     textSize?: number;
-    textFamily?: string;
+    textFontFamily?: string;
     width?: number;
     onPress?(): void;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,7 +38,7 @@ declare module "react-native-really-awesome-button" {
     textLineHeight?: number;
     textSize?: number;
     textFontFamily?: string;
-    width?: number;
+    width?: number | string;
     onPress?(): void;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ export default class Button extends React.Component {
     textColor: PropTypes.string,
     textLineHeight: PropTypes.number,
     textSize: PropTypes.number,
-    textFamily: PropTypes.string,
+    textFontFamily: PropTypes.string,
     width: PropTypes.number
   };
 


### PR DESCRIPTION
Passing a `textFamily` property isn't working as it is actually `textFontFamily` everywhere in the code - except the typing. 

I think there was some confusion when typing/naming this field. If you prefer `textFamily`, let me know. I can change the PR.
