### PR TITLE
fix width protoTypes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ export default class Button extends React.Component {
     textLineHeight: PropTypes.number,
     textSize: PropTypes.number,
     textFamily: PropTypes.string,
-    width: PropTypes.number
+    width: PropTypes.oneOfType([ PropTypes.string, PropTypes.number ])
   };
 
   static defaultProps = {


### PR DESCRIPTION
this change fixed annoying warning when you set percentage to the width
as you can see in the following image
![image](https://user-images.githubusercontent.com/46004092/84940625-5a7f7500-b0f5-11ea-9aee-2ad8a57e9bbb.png)