### PR TITLE
chore: release 3.0.1

### DIFF
--- a/demo/src/components/Example.tsx
+++ b/demo/src/components/Example.tsx
@@ -19,6 +19,16 @@ const TRANSITION_VARIANTS: ButtonVariant[] = [
   'danger',
 ];
 const TEXT_TRANSITION_LABELS = ['welcome', 'Level 2', 'Mission#42', 'Go#3'];
+const HEAVY_JS_TASK_MS = 900;
+
+function simulateHeavyJsTask(durationMs: number) {
+  const start = Date.now();
+
+  while (Date.now() - start < durationMs) {
+    // Intentionally block the JS thread to simulate expensive work.
+    Math.sqrt(Math.random() * durationMs);
+  }
+}
 
 export default function Example({ index }: ThemeExampleProps) {
   const theme = getTheme(index);
@@ -42,6 +52,12 @@ export default function Example({ index }: ThemeExampleProps) {
     setTextTransitionIndex((currentIndex) => {
       return (currentIndex + 1) % TEXT_TRANSITION_LABELS.length;
     });
+  };
+  const handleHeavyStretchProgressPress: ProgressDemoHandler = (
+    next?: ProgressCompletionHandler
+  ) => {
+    simulateHeavyJsTask(HEAVY_JS_TASK_MS);
+    next?.();
   };
 
   useEffect(() => {
@@ -382,6 +398,17 @@ export default function Example({ index }: ThemeExampleProps) {
             stretch
           >
             Primary Large Stretch
+          </ThemedButton>
+          <ThemedButton
+            config={theme}
+            style={styles.button}
+            type="primary"
+            size="large"
+            progress
+            stretch
+            onPress={handleHeavyStretchProgressPress}
+          >
+            Stretch Progress + JS Load
           </ThemedButton>
         </Section>
       </Container>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rcaferati/react-native-awesome-button",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "React Native button component that renders a 60fps animated set of progress-enabled 3D buttons.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -48,6 +48,9 @@
   "homepage": "https://github.com/rcaferati/react-native-awesome-button#readme",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
+  },
+  "dependencies": {
+    "@rcaferati/wac": "1.2.0"
   },
   "devDependencies": {
     "@arkweid/lefthook": "^0.7.7",

--- a/src/__tests__/interactions.test.js
+++ b/src/__tests__/interactions.test.js
@@ -3,28 +3,38 @@ import renderer, { act } from 'react-test-renderer';
 import AwesomeButton from '../Button';
 
 jest.mock('../helpers', () => {
+  const actualHelpers = jest.requireActual('../helpers');
   const createAnimation = () => ({
     start: (callback) => callback && callback({ finished: true }),
     stop: jest.fn(),
   });
 
   return {
+    ...actualHelpers,
     animateElastic: jest.fn(() => createAnimation()),
     animateSpring: jest.fn(() => createAnimation()),
     animateTiming: jest.fn(() => createAnimation()),
   };
 });
 
+const mockedHelpers = jest.requireMock('../helpers');
+const defaultAnimateSpringImplementation =
+  mockedHelpers.animateSpring.getMockImplementation();
+
 const createPressEvent = () => ({
   nativeEvent: {},
 });
 
+const flushMicrotasks = async () => Promise.resolve();
+
 describe('AwesomeButton interactions', () => {
   const originalRequestAnimationFrame = global.requestAnimationFrame;
   const originalCancelAnimationFrame = global.cancelAnimationFrame;
+  const originalWindow = global.window;
 
   beforeEach(() => {
     jest.useFakeTimers();
+    global.window = global;
     global.requestAnimationFrame = (callback) => {
       callback();
       return 0;
@@ -32,14 +42,18 @@ describe('AwesomeButton interactions', () => {
     global.cancelAnimationFrame = jest.fn();
   });
 
-  afterEach(() => {
-    jest.runOnlyPendingTimers();
+  afterEach(async () => {
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+      await flushMicrotasks();
+    });
     jest.useRealTimers();
     global.requestAnimationFrame = originalRequestAnimationFrame;
     global.cancelAnimationFrame = originalCancelAnimationFrame;
+    global.window = originalWindow;
   });
 
-  it('dispatches onPress from the press handler without requiring a hold gesture', () => {
+  it('dispatches onPress from the press handler without requiring a hold gesture', async () => {
     const onPress = jest.fn();
     const component = renderer.create(
       <AwesomeButton onPress={onPress}>Tap</AwesomeButton>
@@ -48,8 +62,48 @@ describe('AwesomeButton interactions', () => {
       testID: 'aws-btn-content-view',
     });
 
-    act(() => {
+    await act(async () => {
       pressable.props.onPress();
+      await flushMicrotasks();
+    });
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('defers onPress until the configured release frames have passed', async () => {
+    const onPress = jest.fn();
+    let timestamp = 0;
+
+    global.requestAnimationFrame = (callback) =>
+      setTimeout(() => {
+        timestamp += 16;
+        callback(timestamp);
+      }, 16);
+    global.cancelAnimationFrame = (handle) => clearTimeout(handle);
+
+    const component = renderer.create(
+      <AwesomeButton onPress={onPress}>Tap</AwesomeButton>
+    );
+    const pressable = component.root.findByProps({
+      testID: 'aws-btn-content-view',
+    });
+
+    await act(async () => {
+      pressable.props.onPress();
+    });
+
+    expect(onPress).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(16);
+      await flushMicrotasks();
+    });
+
+    expect(onPress).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(16);
+      await flushMicrotasks();
     });
 
     expect(onPress).toHaveBeenCalledTimes(1);
@@ -73,7 +127,46 @@ describe('AwesomeButton interactions', () => {
     expect(onPress).not.toHaveBeenCalled();
   });
 
-  it('does not allow dangerouslySetPressableProps to override core press handlers', () => {
+  it('defers onPressOut observers until the release frames have passed', async () => {
+    const onPressOut = jest.fn();
+    let timestamp = 0;
+
+    global.requestAnimationFrame = (callback) =>
+      setTimeout(() => {
+        timestamp += 16;
+        callback(timestamp);
+      }, 16);
+    global.cancelAnimationFrame = (handle) => clearTimeout(handle);
+
+    const component = renderer.create(
+      <AwesomeButton onPressOut={onPressOut}>Tap</AwesomeButton>
+    );
+    const pressable = component.root.findByProps({
+      testID: 'aws-btn-content-view',
+    });
+
+    await act(async () => {
+      pressable.props.onPressOut(createPressEvent());
+    });
+
+    expect(onPressOut).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(16);
+      await flushMicrotasks();
+    });
+
+    expect(onPressOut).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(16);
+      await flushMicrotasks();
+    });
+
+    expect(onPressOut).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not allow dangerouslySetPressableProps to override core press handlers', async () => {
     const onPress = jest.fn();
     const dangerousOnPress = jest.fn();
     const dangerousOnPressIn = jest.fn();
@@ -94,11 +187,12 @@ describe('AwesomeButton interactions', () => {
       testID: 'aws-btn-content-view',
     });
 
-    act(() => {
+    await act(async () => {
       pressable.props.onPressIn(createPressEvent());
       pressable.props.onPress();
       pressable.props.onPressOut(createPressEvent());
       jest.runAllTimers();
+      await flushMicrotasks();
     });
 
     expect(onPress).toHaveBeenCalledTimes(1);
@@ -153,7 +247,7 @@ describe('AwesomeButton interactions', () => {
     });
   });
 
-  it('starts and completes progress button flows through the onPress callback contract', () => {
+  it('starts and completes progress button flows through the onPress callback contract', async () => {
     const onProgressStart = jest.fn();
     const onProgressEnd = jest.fn();
     const onPress = jest.fn((next) => next && next());
@@ -171,9 +265,10 @@ describe('AwesomeButton interactions', () => {
       testID: 'aws-btn-content-view',
     });
 
-    act(() => {
+    await act(async () => {
       pressable.props.onPress();
       jest.runAllTimers();
+      await flushMicrotasks();
     });
 
     expect(onPress).toHaveBeenCalledTimes(1);
@@ -182,7 +277,7 @@ describe('AwesomeButton interactions', () => {
     expect(onProgressEnd).toHaveBeenCalledTimes(1);
   });
 
-  it('does not emit duplicate release callbacks when progress is interrupted by press-out', () => {
+  it('does not emit duplicate release callbacks when progress is interrupted by press-out', async () => {
     const onPressedOut = jest.fn();
     const onPress = jest.fn((next) => next && next());
     let timestamp = 0;
@@ -207,13 +302,99 @@ describe('AwesomeButton interactions', () => {
       testID: 'aws-btn-content-view',
     });
 
-    act(() => {
+    await act(async () => {
       pressable.props.onPressIn(createPressEvent());
       pressable.props.onPress();
       pressable.props.onPressOut(createPressEvent());
       jest.runAllTimers();
+      await flushMicrotasks();
+      jest.runAllTimers();
+      await flushMicrotasks();
     });
 
     expect(onPressedOut).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not restart progress when a blocked loading touch is released after loading ends', async () => {
+    let finishProgress;
+    const onPress = jest.fn((next) => {
+      finishProgress = next;
+    });
+    const component = renderer.create(
+      <AwesomeButton progress onPress={onPress}>
+        Progress
+      </AwesomeButton>
+    );
+    const pressable = component.root.findByProps({
+      testID: 'aws-btn-content-view',
+    });
+
+    await act(async () => {
+      pressable.props.onPressIn(createPressEvent());
+      pressable.props.onPressOut(createPressEvent());
+      pressable.props.onPress();
+      jest.runAllTimers();
+      await flushMicrotasks();
+    });
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(typeof finishProgress).toBe('function');
+
+    await act(async () => {
+      pressable.props.onPressIn(createPressEvent());
+    });
+
+    await act(async () => {
+      finishProgress();
+      jest.runAllTimers();
+      await flushMicrotasks();
+      jest.runAllTimers();
+      await flushMicrotasks();
+    });
+
+    await act(async () => {
+      pressable.props.onPressOut(createPressEvent());
+      pressable.props.onPress();
+      jest.runAllTimers();
+      await flushMicrotasks();
+    });
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a new tap to interrupt the release animation lock on non-progress buttons', async () => {
+    const onPress = jest.fn();
+    const lockedAnimation = {
+      start: () => undefined,
+      stop: jest.fn(),
+    };
+
+    mockedHelpers.animateSpring.mockImplementation(() => lockedAnimation);
+
+    try {
+      const component = renderer.create(
+        <AwesomeButton springRelease onPress={onPress}>
+          Tap
+        </AwesomeButton>
+      );
+      const pressable = component.root.findByProps({
+        testID: 'aws-btn-content-view',
+      });
+
+      await act(async () => {
+        pressable.props.onPressIn(createPressEvent());
+        pressable.props.onPressOut(createPressEvent());
+        pressable.props.onPressIn(createPressEvent());
+        pressable.props.onPressOut(createPressEvent());
+        pressable.props.onPress();
+        await flushMicrotasks();
+      });
+
+      expect(onPress).toHaveBeenCalledTimes(1);
+    } finally {
+      mockedHelpers.animateSpring.mockImplementation(
+        defaultAnimateSpringImplementation
+      );
+    }
   });
 });

--- a/src/__tests__/textTransition.test.js
+++ b/src/__tests__/textTransition.test.js
@@ -11,12 +11,14 @@ import {
 } from '../textTransition';
 
 jest.mock('../helpers', () => {
+  const actualHelpers = jest.requireActual('../helpers');
   const createAnimation = () => ({
     start: (callback) => callback?.({ finished: true }),
     stop: jest.fn(),
   });
 
   return {
+    ...actualHelpers,
     animateElastic: jest.fn(() => createAnimation()),
     animateSpring: jest.fn(() => createAnimation()),
     animateTiming: jest.fn(() => createAnimation()),

--- a/src/usePressProgressController.ts
+++ b/src/usePressProgressController.ts
@@ -1,10 +1,16 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Animated, type GestureResponderEvent } from 'react-native';
+import { frameThrower } from '@rcaferati/wac';
 import debounce from 'lodash.debounce';
 import { animateElastic, animateSpring, animateTiming } from './helpers';
 import { cancelFrame, requestFrame } from './frameLoop';
 import { ANIMATED_TIMING_OFF, DEFAULT_DEBOUNCED_PRESS_TIME } from './constants';
 import type { AwesomeButtonOnPress, ProgressCompletionHandler } from './types';
+
+// WAC's frameThrower waits "future frames" plus one extra layout hop,
+// so 1 gives us roughly two animation frames before running onPress.
+const PRESS_ACTION_FRAME_THROW = 1;
+const PRESS_OUT_OBSERVER_FRAME_THROW = 1;
 
 type PressProgressControllerOptions = {
   activeOpacity: number;
@@ -33,6 +39,8 @@ type PressProgressControllerOptions = {
 type DebouncedPressHandler = AwesomeButtonOnPress & {
   cancel?: () => void;
 };
+
+type PressGestureDisposition = 'idle' | 'armed' | 'blocked';
 
 const usePressProgressController = ({
   activeOpacity,
@@ -64,11 +72,19 @@ const usePressProgressController = ({
   const progressEndFrameRef = useRef<ReturnType<typeof requestFrame> | null>(
     null
   );
+  const releasedGestureClearTimeoutRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
   const releaseFrameRef = useRef<ReturnType<typeof requestFrame> | null>(null);
   const progressStartFrameRef = useRef<ReturnType<typeof requestFrame> | null>(
     null
   );
+  const activeGestureDispositionRef = useRef<PressGestureDisposition>('idle');
+  const releasedGestureDispositionRef = useRef<PressGestureDisposition>('idle');
+  const pressActionFrameTokenRef = useRef(0);
+  const pressOutObserverFrameTokenRef = useRef(0);
   const pressAnimation = useRef<Animated.CompositeAnimation | null>(null);
+  const releaseAnimationRef = useRef<Animated.CompositeAnimation | null>(null);
 
   const debouncedPress = useMemo<DebouncedPressHandler>(() => {
     if (debouncedPressTime === 0) {
@@ -89,17 +105,24 @@ const usePressProgressController = ({
 
   const cancelPendingFrames = useCallback(() => {
     cancelFrame(progressEndFrameRef.current);
+    clearTimeout(releasedGestureClearTimeoutRef.current ?? undefined);
     cancelFrame(releaseFrameRef.current);
     cancelFrame(progressStartFrameRef.current);
     progressEndFrameRef.current = null;
+    releasedGestureClearTimeoutRef.current = null;
     releaseFrameRef.current = null;
     progressStartFrameRef.current = null;
+    activeGestureDispositionRef.current = 'idle';
+    releasedGestureDispositionRef.current = 'idle';
+    pressActionFrameTokenRef.current += 1;
+    pressOutObserverFrameTokenRef.current += 1;
   }, []);
 
   useEffect(() => {
     return () => {
       cancelPendingFrames();
       pressAnimation.current?.stop();
+      releaseAnimationRef.current?.stop();
       debouncedPress.cancel?.();
     };
   }, [cancelPendingFrames, debouncedPress]);
@@ -178,6 +201,7 @@ const usePressProgressController = ({
         }
 
         releasing.current = false;
+        releaseAnimationRef.current = null;
         pressed.current = false;
         callback?.();
         onPressedOut();
@@ -216,6 +240,7 @@ const usePressProgressController = ({
               }),
             ]);
 
+      releaseAnimationRef.current = releaseAnimation;
       releaseAnimation.start(finishRelease);
     },
     [
@@ -226,6 +251,18 @@ const usePressProgressController = ({
       springRelease,
     ]
   );
+
+  const interruptRelease = useCallback(() => {
+    if (releasing.current !== true) {
+      return;
+    }
+
+    releaseAnimationRef.current?.stop();
+    releaseAnimationRef.current = null;
+    releasing.current = false;
+    pressed.current = false;
+    onPressedOut();
+  }, [onPressedOut]);
 
   const animateProgressEnd = useCallback<ProgressCompletionHandler>(
     (callback) => {
@@ -300,14 +337,98 @@ const usePressProgressController = ({
     animateContentOut();
   }, [animateContentOut, animateLoadingStart, onProgressStart]);
 
+  const setActiveGestureDisposition = useCallback(
+    (disposition: PressGestureDisposition) => {
+      clearTimeout(releasedGestureClearTimeoutRef.current ?? undefined);
+      releasedGestureClearTimeoutRef.current = null;
+      releasedGestureDispositionRef.current = 'idle';
+      activeGestureDispositionRef.current = disposition;
+    },
+    []
+  );
+
+  const consumeGestureDisposition = useCallback(() => {
+    const disposition =
+      releasedGestureDispositionRef.current !== 'idle'
+        ? releasedGestureDispositionRef.current
+        : activeGestureDispositionRef.current;
+
+    activeGestureDispositionRef.current = 'idle';
+    releasedGestureDispositionRef.current = 'idle';
+    clearTimeout(releasedGestureClearTimeoutRef.current ?? undefined);
+    releasedGestureClearTimeoutRef.current = null;
+
+    return disposition;
+  }, []);
+
+  const finalizeGestureDisposition = useCallback(() => {
+    const disposition = activeGestureDispositionRef.current;
+
+    if (disposition === 'idle') {
+      return;
+    }
+
+    activeGestureDispositionRef.current = 'idle';
+    releasedGestureDispositionRef.current = disposition;
+    clearTimeout(releasedGestureClearTimeoutRef.current ?? undefined);
+    releasedGestureClearTimeoutRef.current = setTimeout(() => {
+      releasedGestureClearTimeoutRef.current = null;
+      releasedGestureDispositionRef.current = 'idle';
+    }, 0);
+  }, []);
+
   const invokePressAction = useCallback(
     (next?: ProgressCompletionHandler) => {
-      debouncedPress(next);
+      const frameThrowToken = pressActionFrameTokenRef.current + 1;
+      pressActionFrameTokenRef.current = frameThrowToken;
+
+      frameThrower(PRESS_ACTION_FRAME_THROW).then(() => {
+        if (pressActionFrameTokenRef.current !== frameThrowToken) {
+          return;
+        }
+
+        if (disabled === true || hasChildren === false) {
+          return;
+        }
+
+        debouncedPress(next);
+      });
     },
-    [debouncedPress]
+    [debouncedPress, disabled, hasChildren]
+  );
+
+  const invokePressOutObserver = useCallback(
+    (event: GestureResponderEvent) => {
+      event.persist?.();
+      const frameThrowToken = pressOutObserverFrameTokenRef.current + 1;
+      pressOutObserverFrameTokenRef.current = frameThrowToken;
+
+      frameThrower(PRESS_OUT_OBSERVER_FRAME_THROW).then(() => {
+        if (pressOutObserverFrameTokenRef.current !== frameThrowToken) {
+          return;
+        }
+
+        if (disabled === true || hasChildren === false) {
+          return;
+        }
+
+        onPressOut(event);
+      });
+    },
+    [disabled, hasChildren, onPressOut]
   );
 
   const handlePress = useCallback(() => {
+    const gestureDisposition = consumeGestureDisposition();
+
+    if (gestureDisposition === 'blocked') {
+      return;
+    }
+
+    if (gestureDisposition === 'idle' && releasing.current === true) {
+      return;
+    }
+
     if (
       disabled === true ||
       hasChildren === false ||
@@ -329,6 +450,7 @@ const usePressProgressController = ({
 
     invokePressAction();
   }, [
+    consumeGestureDisposition,
     animateProgressEnd,
     disabled,
     hasChildren,
@@ -343,18 +465,40 @@ const usePressProgressController = ({
       releaseFrameRef.current = null;
 
       if (
+        disabled !== true &&
+        hasChildren === true &&
+        releasing.current === true &&
+        progressing.current === false &&
+        pressed.current === false
+      ) {
+        interruptRelease();
+      }
+
+      if (
         disabled === true ||
         hasChildren === false ||
         progressing.current === true ||
         pressed.current === true
       ) {
+        if (progressing.current === true || pressed.current === true) {
+          setActiveGestureDisposition('blocked');
+        }
+
         return;
       }
 
+      setActiveGestureDisposition('armed');
       onPressIn(event);
       animatePressIn();
     },
-    [animatePressIn, disabled, hasChildren, onPressIn]
+    [
+      animatePressIn,
+      disabled,
+      hasChildren,
+      interruptRelease,
+      onPressIn,
+      setActiveGestureDisposition,
+    ]
   );
 
   const handlePressOut = useCallback(
@@ -363,7 +507,12 @@ const usePressProgressController = ({
         return;
       }
 
-      onPressOut(event);
+      invokePressOutObserver(event);
+      finalizeGestureDisposition();
+
+      if (releasing.current === true) {
+        return;
+      }
 
       if (progress === true && progressing.current === true) {
         return;
@@ -371,7 +520,14 @@ const usePressProgressController = ({
 
       scheduleRelease();
     },
-    [disabled, hasChildren, onPressOut, progress, scheduleRelease]
+    [
+      disabled,
+      finalizeGestureDisposition,
+      hasChildren,
+      invokePressOutObserver,
+      progress,
+      scheduleRelease,
+    ]
   );
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2477,6 +2477,7 @@ __metadata:
     "@babel/eslint-parser": "npm:^7.18.2"
     "@babel/runtime": "npm:^7.28.4"
     "@commitlint/config-conventional": "npm:^17.0.2"
+    "@rcaferati/wac": "npm:1.2.0"
     "@react-native-community/eslint-config": "npm:^3.0.2"
     "@react-native/babel-preset": "npm:0.76.0"
     "@release-it/conventional-changelog": "npm:^5.0.0"
@@ -2502,6 +2503,13 @@ __metadata:
     react-native: ">=0.76.0"
   languageName: unknown
   linkType: soft
+
+"@rcaferati/wac@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@rcaferati/wac@npm:1.2.0"
+  checksum: 10c0/be11bd4390aeb26702126eb6327be0d5e2df7030f24b989c57db626e19c3a1489b6715929257a3279f044e2e0d4e4180ee3741ca7834cedd6de148f114011619
+  languageName: node
+  linkType: hard
 
 "@react-native-community/eslint-config@npm:^3.0.2":
   version: 3.2.0
@@ -2938,7 +2946,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:20.5.1":
+"@types/node@npm:*":
+  version: 25.6.0
+  resolution: "@types/node@npm:25.6.0"
+  dependencies:
+    undici-types: "npm:~7.19.0"
+  checksum: 10c0/d2d2015630ff098a201407f55f5077a20270ae4f465c739b40865cd9933b91b9c5d2b85568eadaf3db0801b91e267333ca7eb39f007428b173d1cdab4b339ac5
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:20.5.1":
   version: 20.5.1
   resolution: "@types/node@npm:20.5.1"
   checksum: 10c0/b5aeaeb489842081190f8c2c09e923ff7b1b4ee3ecfceba12ba1030ce7750909a1b3c0f5372bd60cbe955e48a9889f416522e8a96697ad7209317752f395e3e5
@@ -3515,6 +3532,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"async-generator-function@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "async-generator-function@npm:1.0.0"
+  checksum: 10c0/2c50ef856c543ad500d8d8777d347e3c1ba623b93e99c9263ecc5f965c1b12d2a140e2ab6e43c3d0b85366110696f28114649411cbcd10b452a92a2318394186
+  languageName: node
+  linkType: hard
+
 "async-limiter@npm:~1.0.0":
   version: 1.0.1
   resolution: "async-limiter@npm:1.0.1"
@@ -4041,7 +4065,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:5.2.0, chalk@npm:^5.0.0":
+"chalk@npm:5.2.0":
   version: 5.2.0
   resolution: "chalk@npm:5.2.0"
   checksum: 10c0/8a519b35c239f96e041b7f1ed8fdd79d3ca2332a8366cb957378b8a1b8a4cdfb740d19628e8bf74654d4c0917aa10cf39c20752e177a1304eac29a1168a740e9
@@ -4058,7 +4082,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^5.0.1, chalk@npm:^5.2.0":
+"chalk@npm:^5.0.0, chalk@npm:^5.0.1, chalk@npm:^5.2.0":
   version: 5.6.2
   resolution: "chalk@npm:5.6.2"
   checksum: 10c0/99a4b0f0e7991796b1e7e3f52dceb9137cae2a9dfc8fc0784a550dc4c558e15ab32ed70b14b21b52beb2679b4892b41a0aa44249bcb996f01e125d58477c6976
@@ -5958,9 +5982,9 @@ __metadata:
   linkType: hard
 
 "flow-parser@npm:0.*":
-  version: 0.121.0
-  resolution: "flow-parser@npm:0.121.0"
-  checksum: 10c0/831cf56b2ed987677fd056fd5a035aee88c9c474c507e14e8ffd85374da7b42236a7280a801fc893779331be638c2c4f8af3fb654a298f8ed16c209926450576
+  version: 0.309.0
+  resolution: "flow-parser@npm:0.309.0"
+  checksum: 10c0/2c0bb48365a0d78ad2d6571f1a403c133589b40f0f9fe1d9d5ee20e70d3d88bc834ff932023df0a48d96aa05c3dc81ae17d9d61e35a80234506cdb51f2a0572c
   languageName: node
   linkType: hard
 
@@ -6103,20 +6127,23 @@ __metadata:
   linkType: hard
 
 "get-intrinsic@npm:^1.1.3, get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.2.7, get-intrinsic@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "get-intrinsic@npm:1.3.0"
+  version: 1.3.1
+  resolution: "get-intrinsic@npm:1.3.1"
   dependencies:
+    async-function: "npm:^1.0.0"
+    async-generator-function: "npm:^1.0.0"
     call-bind-apply-helpers: "npm:^1.0.2"
     es-define-property: "npm:^1.0.1"
     es-errors: "npm:^1.3.0"
     es-object-atoms: "npm:^1.1.1"
     function-bind: "npm:^1.1.2"
+    generator-function: "npm:^2.0.0"
     get-proto: "npm:^1.0.1"
     gopd: "npm:^1.2.0"
     has-symbols: "npm:^1.1.0"
     hasown: "npm:^2.0.2"
     math-intrinsics: "npm:^1.1.0"
-  checksum: 10c0/52c81808af9a8130f581e6a6a83e1ba4a9f703359e7a438d1369a5267a25412322f03dcbd7c549edaef0b6214a0630a28511d7df0130c93cfd380f4fa0b5b66a
+  checksum: 10c0/9f4ab0cf7efe0fd2c8185f52e6f637e708f3a112610c88869f8f041bb9ecc2ce44bf285dfdbdc6f4f7c277a5b88d8e94a432374d97cca22f3de7fc63795deb5d
   languageName: node
   linkType: hard
 
@@ -11850,12 +11877,12 @@ __metadata:
   linkType: hard
 
 "typescript@npm:^4.6.4 || ^5.2.2":
-  version: 4.9.5
-  resolution: "typescript@npm:4.9.5"
+  version: 5.9.3
+  resolution: "typescript@npm:5.9.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/5f6cad2e728a8a063521328e612d7876e12f0d8a8390d3b3aaa452a6a65e24e9ac8ea22beb72a924fd96ea0a49ea63bb4e251fb922b12eedfb7f7a26475e5c56
+  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
   languageName: node
   linkType: hard
 
@@ -11870,12 +11897,12 @@ __metadata:
   linkType: hard
 
 "typescript@patch:typescript@npm%3A^4.6.4 || ^5.2.2#optional!builtin<compat/typescript>":
-  version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#optional!builtin<compat/typescript>::version=4.9.5&hash=289587"
+  version: 5.9.3
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=cef18b"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/e3333f887c6829dfe0ab6c1dbe0dd1e3e2aeb56c66460cb85c5440c566f900c833d370ca34eb47558c0c69e78ced4bfe09b8f4f98b6de7afed9b84b8d1dd06a1
+  checksum: 10c0/6f7e53bf0d9702350deeb6f35e08b69cbc8b958c33e0ec77bdc0ad6a6c8e280f3959dcbfde6f5b0848bece57810696489deaaa53d75de3578ff255d168c1efbd
   languageName: node
   linkType: hard
 
@@ -11904,6 +11931,13 @@ __metadata:
   version: 0.1.2
   resolution: "unc-path-regex@npm:0.1.2"
   checksum: 10c0/bf9c781c4e2f38e6613ea17a51072e4b416840fbe6eeb244597ce9b028fac2fb6cfd3dde1f14111b02c245e665dc461aab8168ecc30b14364d02caa37f812996
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~7.19.0":
+  version: 7.19.2
+  resolution: "undici-types@npm:7.19.2"
+  checksum: 10c0/7159f10546f9f6c47d36776bb1bbf8671e87c1e587a6fee84ae1f111ae8de4f914efa8ca0dfcd224f4f4a9dfc3f6028f627ccb5ddaccf82d7fd54671b89fac3e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- update the package version to 3.0.1
- harden press/progress gesture handling to block stale progress touches
- allow non-progress buttons to interrupt the release lock for fast repeated taps
- keep the expo demo aligned with the frame-thrower and heavy-JS progress coverage

## Validation
- yarn test --runInBand
- yarn typescript
- yarn lint