### PR TITLE
fix: harden deferred progress presses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rcaferati/react-native-awesome-button",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "React Native button component that renders a 60fps animated set of progress-enabled 3D buttons.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/__tests__/interactions.test.js
+++ b/src/__tests__/interactions.test.js
@@ -277,6 +277,132 @@ describe('AwesomeButton interactions', () => {
     expect(onProgressEnd).toHaveBeenCalledTimes(1);
   });
 
+  it('still dispatches onPress when the parent rerenders during the deferred progress window', async () => {
+    const consumerOnPress = jest.fn((next) => next && next());
+    let timestamp = 0;
+
+    global.requestAnimationFrame = (callback) =>
+      setTimeout(() => {
+        timestamp += 16;
+        callback(timestamp);
+      }, 16);
+    global.cancelAnimationFrame = (handle) => clearTimeout(handle);
+
+    function Wrapper() {
+      const [tick, setTick] = React.useState(0);
+
+      return (
+        <AwesomeButton
+          progress
+          onProgressStart={() => {
+            setTick((value) => value + 1);
+          }}
+          onPress={(next) => {
+            consumerOnPress(next);
+          }}
+        >
+          {`Progress ${tick}`}
+        </AwesomeButton>
+      );
+    }
+
+    const component = renderer.create(<Wrapper />);
+    const pressable = component.root.findByProps({
+      testID: 'aws-btn-content-view',
+    });
+
+    await act(async () => {
+      pressable.props.onPress();
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(16);
+      await flushMicrotasks();
+    });
+
+    expect(consumerOnPress).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(16);
+      await flushMicrotasks();
+    });
+
+    expect(consumerOnPress).toHaveBeenCalledTimes(1);
+    expect(typeof consumerOnPress.mock.calls[0][0]).toBe('function');
+  });
+
+  it('rolls back a deferred progress press when the button becomes disabled mid-flight', async () => {
+    const consumerOnPress = jest.fn();
+    let timestamp = 0;
+
+    global.requestAnimationFrame = (callback) =>
+      setTimeout(() => {
+        timestamp += 16;
+        callback(timestamp);
+      }, 16);
+    global.cancelAnimationFrame = (handle) => clearTimeout(handle);
+
+    function Wrapper() {
+      const [disabled, setDisabled] = React.useState(false);
+
+      return (
+        <AwesomeButton
+          disabled={disabled}
+          progress
+          onProgressStart={() => {
+            setDisabled(true);
+          }}
+          onPress={(next) => {
+            consumerOnPress(next);
+          }}
+        >
+          Progress
+        </AwesomeButton>
+      );
+    }
+
+    const component = renderer.create(<Wrapper />);
+    const pressable = component.root.findByProps({
+      testID: 'aws-btn-content-view',
+    });
+
+    await act(async () => {
+      pressable.props.onPress();
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(16);
+      await flushMicrotasks();
+    });
+
+    expect(
+      component.root.findByProps({ testID: 'aws-btn-content-view' }).props
+        .accessibilityState
+    ).toMatchObject({
+      busy: true,
+      disabled: true,
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(16);
+      await flushMicrotasks();
+      jest.runAllTimers();
+      await flushMicrotasks();
+    });
+
+    expect(consumerOnPress).not.toHaveBeenCalled();
+    expect(
+      component.root.findByProps({ testID: 'aws-btn-content-view' }).props
+        .accessibilityState
+    ).toMatchObject({
+      disabled: true,
+    });
+    expect(
+      component.root.findByProps({ testID: 'aws-btn-content-view' }).props
+        .accessibilityState?.busy
+    ).not.toBe(true);
+  });
+
   it('does not emit duplicate release callbacks when progress is interrupted by press-out', async () => {
     const onPressedOut = jest.fn();
     const onPress = jest.fn((next) => next && next());

--- a/src/usePressProgressController.ts
+++ b/src/usePressProgressController.ts
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { Animated, type GestureResponderEvent } from 'react-native';
 import { frameThrower } from '@rcaferati/wac';
 import debounce from 'lodash.debounce';
@@ -85,14 +92,30 @@ const usePressProgressController = ({
   const pressOutObserverFrameTokenRef = useRef(0);
   const pressAnimation = useRef<Animated.CompositeAnimation | null>(null);
   const releaseAnimationRef = useRef<Animated.CompositeAnimation | null>(null);
+  const progressLoadingAnimationRef =
+    useRef<Animated.CompositeAnimation | null>(null);
+  const progressContentOutAnimationRef =
+    useRef<Animated.CompositeAnimation | null>(null);
+  const progressStartedRef = useRef(false);
+  const onPressRef = useRef(onPress);
+  const onPressOutRef = useRef(onPressOut);
+  const disabledRef = useRef(disabled);
+  const hasChildrenRef = useRef(hasChildren);
+
+  useLayoutEffect(() => {
+    onPressRef.current = onPress;
+    onPressOutRef.current = onPressOut;
+    disabledRef.current = disabled;
+    hasChildrenRef.current = hasChildren;
+  });
 
   const debouncedPress = useMemo<DebouncedPressHandler>(() => {
     if (debouncedPressTime === 0) {
-      return (next) => onPress(next);
+      return (next) => onPressRef.current(next);
     }
 
     const handler = debounce(
-      (next?: ProgressCompletionHandler) => onPress(next),
+      (next?: ProgressCompletionHandler) => onPressRef.current(next),
       debouncedPressTime,
       {
         trailing: false,
@@ -101,31 +124,45 @@ const usePressProgressController = ({
     );
 
     return handler as DebouncedPressHandler;
-  }, [debouncedPressTime, onPress]);
+  }, [debouncedPressTime]);
+  const debouncedPressRef = useRef<DebouncedPressHandler>(debouncedPress);
+
+  useLayoutEffect(() => {
+    debouncedPressRef.current = debouncedPress;
+  }, [debouncedPress]);
+
+  const stopProgressStartAnimations = useCallback(() => {
+    progressLoadingAnimationRef.current?.stop();
+    progressContentOutAnimationRef.current?.stop();
+    progressLoadingAnimationRef.current = null;
+    progressContentOutAnimationRef.current = null;
+  }, []);
 
   const cancelPendingFrames = useCallback(() => {
     cancelFrame(progressEndFrameRef.current);
     clearTimeout(releasedGestureClearTimeoutRef.current ?? undefined);
     cancelFrame(releaseFrameRef.current);
     cancelFrame(progressStartFrameRef.current);
+    stopProgressStartAnimations();
     progressEndFrameRef.current = null;
     releasedGestureClearTimeoutRef.current = null;
     releaseFrameRef.current = null;
     progressStartFrameRef.current = null;
     activeGestureDispositionRef.current = 'idle';
     releasedGestureDispositionRef.current = 'idle';
+    progressStartedRef.current = false;
     pressActionFrameTokenRef.current += 1;
     pressOutObserverFrameTokenRef.current += 1;
-  }, []);
+  }, [stopProgressStartAnimations]);
 
   useEffect(() => {
     return () => {
       cancelPendingFrames();
       pressAnimation.current?.stop();
       releaseAnimationRef.current?.stop();
-      debouncedPress.cancel?.();
+      debouncedPressRef.current.cancel?.();
     };
-  }, [cancelPendingFrames, debouncedPress]);
+  }, [cancelPendingFrames]);
 
   const animatePressIn = useCallback(() => {
     pressAnimation.current = Animated.parallel([
@@ -160,16 +197,25 @@ const usePressProgressController = ({
   ]);
 
   const animateLoadingStart = useCallback(() => {
+    progressLoadingAnimationRef.current?.stop();
     animatedLoading.setValue(0);
-    animateTiming({
+    const animation = animateTiming({
       variable: animatedLoading,
       toValue: 1,
       duration: progressLoadingTime,
-    }).start();
+    });
+
+    progressLoadingAnimationRef.current = animation;
+    animation.start(() => {
+      if (progressLoadingAnimationRef.current === animation) {
+        progressLoadingAnimationRef.current = null;
+      }
+    });
   }, [animatedLoading, progressLoadingTime]);
 
   const animateContentOut = useCallback(() => {
-    Animated.parallel([
+    progressContentOutAnimationRef.current?.stop();
+    const animation = Animated.parallel([
       animateTiming({
         variable: loadingOpacity,
         toValue: 1,
@@ -182,7 +228,14 @@ const usePressProgressController = ({
         variable: activityOpacity,
         toValue: 1,
       }),
-    ]).start();
+    ]);
+
+    progressContentOutAnimationRef.current = animation;
+    animation.start(() => {
+      if (progressContentOutAnimationRef.current === animation) {
+        progressContentOutAnimationRef.current = null;
+      }
+    });
   }, [activityOpacity, loadingOpacity, textOpacity]);
 
   const animateRelease = useCallback(
@@ -274,6 +327,7 @@ const usePressProgressController = ({
       cancelFrame(releaseFrameRef.current);
       releaseFrameRef.current = null;
       cancelFrame(progressEndFrameRef.current);
+      stopProgressStartAnimations();
       progressEndFrameRef.current = requestFrame(() => {
         progressEndFrameRef.current = null;
         animateTiming({
@@ -297,6 +351,7 @@ const usePressProgressController = ({
           ]).start(() => {
             animateRelease(() => {
               progressing.current = false;
+              progressStartedRef.current = false;
               setActivity(false);
               callback?.();
               onProgressEnd();
@@ -313,6 +368,7 @@ const usePressProgressController = ({
       onProgressEnd,
       progress,
       textOpacity,
+      stopProgressStartAnimations,
     ]
   );
 
@@ -331,11 +387,46 @@ const usePressProgressController = ({
 
   const startProgress = useCallback(() => {
     progressing.current = true;
+    progressStartedRef.current = true;
     onProgressStart();
     setActivity(true);
     animateLoadingStart();
     animateContentOut();
   }, [animateContentOut, animateLoadingStart, onProgressStart]);
+
+  const rollbackProgressPress = useCallback(() => {
+    if (
+      progressStartFrameRef.current !== null &&
+      progressStartedRef.current !== true
+    ) {
+      cancelFrame(progressStartFrameRef.current);
+      progressStartFrameRef.current = null;
+      progressing.current = false;
+      progressStartedRef.current = false;
+      return;
+    }
+
+    stopProgressStartAnimations();
+    progressStartFrameRef.current = null;
+    progressStartedRef.current = false;
+    progressing.current = false;
+    animatedLoading.setValue(0);
+    textOpacity.setValue(1);
+    activityOpacity.setValue(0);
+    loadingOpacity.setValue(0);
+    setActivity(false);
+    animateRelease(() => {
+      onProgressEnd();
+    });
+  }, [
+    activityOpacity,
+    animateRelease,
+    animatedLoading,
+    loadingOpacity,
+    onProgressEnd,
+    stopProgressStartAnimations,
+    textOpacity,
+  ]);
 
   const setActiveGestureDisposition = useCallback(
     (disposition: PressGestureDisposition) => {
@@ -378,7 +469,7 @@ const usePressProgressController = ({
   }, []);
 
   const invokePressAction = useCallback(
-    (next?: ProgressCompletionHandler) => {
+    (next?: ProgressCompletionHandler, onAbort?: () => void) => {
       const frameThrowToken = pressActionFrameTokenRef.current + 1;
       pressActionFrameTokenRef.current = frameThrowToken;
 
@@ -387,36 +478,34 @@ const usePressProgressController = ({
           return;
         }
 
-        if (disabled === true || hasChildren === false) {
+        if (disabledRef.current === true || hasChildrenRef.current === false) {
+          onAbort?.();
           return;
         }
 
         debouncedPress(next);
       });
     },
-    [debouncedPress, disabled, hasChildren]
+    [debouncedPress]
   );
 
-  const invokePressOutObserver = useCallback(
-    (event: GestureResponderEvent) => {
-      event.persist?.();
-      const frameThrowToken = pressOutObserverFrameTokenRef.current + 1;
-      pressOutObserverFrameTokenRef.current = frameThrowToken;
+  const invokePressOutObserver = useCallback((event: GestureResponderEvent) => {
+    event.persist?.();
+    const frameThrowToken = pressOutObserverFrameTokenRef.current + 1;
+    pressOutObserverFrameTokenRef.current = frameThrowToken;
 
-      frameThrower(PRESS_OUT_OBSERVER_FRAME_THROW).then(() => {
-        if (pressOutObserverFrameTokenRef.current !== frameThrowToken) {
-          return;
-        }
+    frameThrower(PRESS_OUT_OBSERVER_FRAME_THROW).then(() => {
+      if (pressOutObserverFrameTokenRef.current !== frameThrowToken) {
+        return;
+      }
 
-        if (disabled === true || hasChildren === false) {
-          return;
-        }
+      if (disabledRef.current === true || hasChildrenRef.current === false) {
+        return;
+      }
 
-        onPressOut(event);
-      });
-    },
-    [disabled, hasChildren, onPressOut]
-  );
+      onPressOutRef.current(event);
+    });
+  }, []);
 
   const handlePress = useCallback(() => {
     const gestureDisposition = consumeGestureDisposition();
@@ -444,7 +533,7 @@ const usePressProgressController = ({
         progressStartFrameRef.current = null;
         startProgress();
       });
-      invokePressAction(animateProgressEnd);
+      invokePressAction(animateProgressEnd, rollbackProgressPress);
       return;
     }
 
@@ -456,6 +545,7 @@ const usePressProgressController = ({
     hasChildren,
     invokePressAction,
     progress,
+    rollbackProgressPress,
     startProgress,
   ]);
 


### PR DESCRIPTION
## Summary
- stabilize deferred progress press callbacks across parent rerenders
- add rollback handling when a deferred progress press becomes invalid mid-flight
- bump the package version to 3.0.2 and cover the race with regression tests

## Verification
- yarn test --runInBand
- yarn typescript
- yarn lint
- npm publish --access public --dry-run